### PR TITLE
fix for potential buffer overflow

### DIFF
--- a/ASVToolkit/ArkSavegameToolkit/SavegameToolkit/ArkArchive.cs
+++ b/ASVToolkit/ArkSavegameToolkit/SavegameToolkit/ArkArchive.cs
@@ -175,14 +175,14 @@ namespace SavegameToolkit {
                 throw new IndexOutOfRangeException();
             }
 
-            bool isLarge = absSize > bufferSize;
+            bool isLarge = readSize > bufferSize;
 
             if (isLarge && reportLargeStrings) {
                 DebugMessage($"String ({absSize}) larger than internal Buffer ({bufferSize})");
             }
 
             if (multibyte) {
-                byte[] buffer = isLarge ? new byte[absSize] : smallByteBuffer;
+                byte[] buffer = isLarge ? new byte[readSize] : smallByteBuffer;
                 mbbReader.Read(buffer, 0, readSize);
                 return Encoding.Unicode.GetString(buffer, 0, readSize - 2);
             } else {


### PR DESCRIPTION
This buffer overflow seems to happen very rarely and more likely if the encoded string is long and doesn't use ASCII but Unicode. A recent change in the mod DinoStorageV2 made that issue appear the first time for me.